### PR TITLE
docs: rewrite CONTRIBUTING.md for open PR-based contribution model

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/improve-skill.yml
+++ b/.github/ISSUE_TEMPLATE/improve-skill.yml
@@ -1,0 +1,46 @@
+name: Improve Existing Skill
+description: Pitch an improvement to an existing skill in the library.
+labels: ["improvement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve an existing skill! Please fill in the details below. A maintainer will review your proposal and give a go-ahead before you start building.
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill name
+      description: The name of the skill you want to improve (e.g. "sap-fiori-guidelines").
+      placeholder: sap-fiori-guidelines
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is missing or incorrect?
+      description: Describe the gap, inaccuracy, or limitation you've found.
+      placeholder: The skill doesn't cover...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed change
+      description: What would you add, update, or remove? Be as specific as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to documentation, guidelines, or other sources that support your proposed change.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else the maintainers should know.

--- a/.github/ISSUE_TEMPLATE/new-skill.yml
+++ b/.github/ISSUE_TEMPLATE/new-skill.yml
@@ -1,0 +1,51 @@
+name: New Skill
+description: Pitch a new skill you'd like to contribute to the library.
+labels: ["new skill"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for pitching a new skill! Please fill in the details below. A maintainer will review your proposal and give a go-ahead before you start building.
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill name
+      description: A short, descriptive name for the skill (e.g. "SAP Fiori Guidelines").
+      placeholder: My Awesome Skill
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What does this skill do?
+      description: Describe what the skill covers and when it should be triggered.
+      placeholder: This skill helps Claude with...
+    validations:
+      required: true
+
+  - type: textarea
+    id: trigger
+    attributes:
+      label: When should this skill trigger?
+      description: List the keywords, topics, or situations that should activate this skill.
+      placeholder: |
+        - Mention of X, Y, Z
+        - When the user asks about...
+    validations:
+      required: true
+
+  - type: textarea
+    id: content-sources
+    attributes:
+      label: Content sources
+      description: What documentation, guidelines, or references would you base this skill on? Include links if available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else the maintainers should know — target audience, related skills, limitations, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,10 @@ Found a typo or want to improve documentation? Fork the repository and open a PR
 
 To avoid duplicate efforts and make sure your contribution is a good fit, please **open an issue first** to pitch your idea or describe the improvement. A maintainer will review it and give a go-ahead via assignment and a comment. Once approved, fork the repository and open a pull request.
 
-We may add issue templates for skill improvements and new skills to make this process easier.
+Use the appropriate issue template to get started:
+
+* [Pitch a new skill](https://github.com/SAP/ai-skills-library/issues/new?template=new-skill.yml)
+* [Propose an improvement to an existing skill](https://github.com/SAP/ai-skills-library/issues/new?template=improve-skill.yml)
 
 ## Governing Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,34 +6,24 @@ All members of the project community must abide by the [SAP Open Source Code of 
 Only by respecting each other we can develop a productive, collaborative community.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [a project maintainer](REUSE.toml).
 
-## Engaging in Our Project
+## How to Contribute
 
-We use GitHub to manage reviews of pull requests.
+We use GitHub to manage pull requests. Everyone is welcome to contribute by forking the repository and opening a pull request.
 
-* If you are a new contributor, see: [Steps to Contribute](#steps-to-contribute)
+### Documentation Fixes
 
-* Before implementing your change, create an issue that describes the problem you would like to solve or the code that should be enhanced. Please note that you are willing to work on that issue.
+Found a typo or want to improve documentation? Fork the repository and open a PR directly — no prior issue needed.
 
-* The team will review the issue and decide whether it should be implemented as a pull request. In that case, they will assign the issue to you. If the team decides against picking up the issue, the team will post a comment with an explanation.
+### Improving an Existing Skill or Adding a New Skill
 
-## Steps to Contribute
+To avoid duplicate efforts and make sure your contribution is a good fit, please **open an issue first** to pitch your idea or describe the improvement. A maintainer will review it and give a go-ahead via assignment and a comment. Once approved, fork the repository and open a pull request.
 
-Should you wish to work on an issue, please claim it first by commenting on the GitHub issue that you want to work on. This is to prevent duplicated efforts from other contributors on the same issue.
+We may add issue templates for skill improvements and new skills to make this process easier.
 
-If you have questions about one of the issues, please comment on them, and one of the maintainers will clarify.
+## Governing Rules
 
-## Contributing Code or Documentation
-
-You are welcome to contribute code in order to fix a bug or to implement a new feature that is logged as an issue.
-
-The following rule governs code contributions:
+The following rules apply to all contributions:
 
 * Contributions must be licensed under the [Apache 2.0 License](./LICENSE).
 * Due to legal reasons, contributors will be asked to accept a Developer Certificate of Origin (DCO) when they create the first pull request to this project. This happens in an automated fashion during the submission process. SAP uses [the standard DCO text of the Linux Foundation](https://developercertificate.org/).
 * Contributions must follow our [guidelines on AI-generated code](https://github.com/SAP/.github/blob/main/CONTRIBUTING_USING_GENAI.md) in case you are using such tools.
-
-## Issues and Planning
-
-* We use GitHub issues to track bugs and enhancement requests.
-
-* Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee.


### PR DESCRIPTION
## Summary

- Remove the mandatory issue-gate-before-PR workflow
- **Docs fixes**: contributors can now fork + PR directly, no issue required
- **Skill improvements / new skills**: open an issue to pitch the idea first, get a maintainer go-ahead (assignment + comment), then fork + PR — keeps duplicate effort low without blocking contributors
- Mention that issue templates for skill work may be added in the future
- Keep Code of Conduct unchanged
- Keep all governing rules unchanged (Apache 2.0, DCO, AI-generated code guidelines)
- Rename section from "Contributing Code or Documentation" to "Governing Rules" for clarity

## Test plan

- [ ] Read the new CONTRIBUTING.md and verify the three contribution paths are clearly described
- [ ] Confirm Code of Conduct section is word-for-word unchanged
- [ ] Confirm governing rules (Apache 2.0, DCO, AI code guidelines) are all still present
- [ ] Confirm no mention of old issue-assignment-before-PR gate remains