### PR TITLE
docs: update new-skill template and contributing guide for bring-your-own-repo model

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-skill.yml
+++ b/.github/ISSUE_TEMPLATE/new-skill.yml
@@ -1,48 +1,46 @@
-name: New Skill
-description: Pitch a new skill you'd like to contribute to the library.
+name: Register a New Skill
+description: Register your skill repository with the AI Skills Library to get it listed on skills.cloud.sap.
 labels: ["new skill"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for pitching a new skill! Please fill in the details below. A maintainer will review your proposal and give a go-ahead before you start building.
+        Thanks for contributing a skill! The AI Skills Library uses a **bring-your-own-repo** model — your skill code stays in your own GitHub repository. Opening this issue kicks off the onboarding process: a maintainer will review your submission and add your repo to the Skill Hub.
+
+        **Before submitting, make sure your repo is ready.** See the checklist below.
 
   - type: input
-    id: skill-name
+    id: repo-url
     attributes:
-      label: Skill name
-      description: A short, descriptive name for the skill (e.g. "SAP Fiori Guidelines").
-      placeholder: My Awesome Skill
+      label: Repository URL
+      description: The public GitHub repository that contains your skill(s). Must be on github.com.
+      placeholder: https://github.com/your-org/your-repo
     validations:
       required: true
 
   - type: textarea
-    id: description
+    id: skills-listing
     attributes:
-      label: What does this skill do?
-      description: Describe what the skill covers and when it should be triggered.
-      placeholder: This skill helps Claude with...
-    validations:
-      required: true
-
-  - type: textarea
-    id: trigger
-    attributes:
-      label: When should this skill trigger?
-      description: List the keywords, topics, or situations that should activate this skill.
+      label: Skills in this repository
+      description: List each skill with its directory slug and a one-line description.
       placeholder: |
-        - Mention of X, Y, Z
-        - When the user asks about...
+        my-skill — Does X when the user asks about Y
+        another-skill — Helps with Z in context of ...
     validations:
       required: true
 
-  - type: textarea
-    id: content-sources
+  - type: checkboxes
+    id: readiness
     attributes:
-      label: Content sources
-      description: What documentation, guidelines, or references would you base this skill on? Include links if available.
-    validations:
-      required: true
+      label: Readiness checklist
+      description: Confirm your repository meets the required structure before submitting.
+      options:
+        - label: The repository is public on github.com
+          required: true
+        - label: Each skill has a `skills/<slug>/SKILL.md` file with `name` and `description` frontmatter
+          required: true
+        - label: The repository root has a `package.json` with an `author` field
+          required: true
 
   - type: textarea
     id: additional-context

--- a/.github/ISSUE_TEMPLATE/new-skill.yml
+++ b/.github/ISSUE_TEMPLATE/new-skill.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for contributing a skill! The AI Skills Library uses a **bring-your-own-repo** model — your skill code stays in your own GitHub repository. Opening this issue kicks off the onboarding process: a maintainer will review your submission and add your repo to the Skill Hub.
+        Thanks for contributing a skill! The AI Skills Library uses a **bring-your-own-repo** model — your skill code stays in your own GitHub repository. Opening this issue kicks off the onboarding process: a maintainer will review your submission and add your repo to the AI Skills Library.
 
         **Before submitting, make sure your repo is ready.** See the checklist below.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,20 +8,50 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 ## How to Contribute
 
-We use GitHub to manage pull requests. Everyone is welcome to contribute by forking the repository and opening a pull request.
-
 ### Documentation Fixes
 
 Found a typo or want to improve documentation? Fork the repository and open a PR directly — no prior issue needed.
 
-### Improving an Existing Skill or Adding a New Skill
+### Improving an Existing Skill
 
-To avoid duplicate efforts and make sure your contribution is a good fit, please **open an issue first** to pitch your idea or describe the improvement. A maintainer will review it and give a go-ahead via assignment and a comment. Once approved, fork the repository and open a pull request.
+To avoid duplicate efforts and make sure your contribution is a good fit, please **open an issue first** to describe the improvement. A maintainer will review it and give a go-ahead via assignment and a comment. Once approved, fork the repository and open a pull request.
 
-Use the appropriate issue template to get started:
-
-* [Pitch a new skill](https://github.com/SAP/ai-skills-library/issues/new?template=new-skill.yml)
 * [Propose an improvement to an existing skill](https://github.com/SAP/ai-skills-library/issues/new?template=improve-skill.yml)
+
+### Registering a New Skill
+
+The AI Skills Library uses a **bring-your-own-repo** model. Your skill code lives in your own public GitHub repository — you do not submit skill code to this repository. Instead, you open an issue to request onboarding, and a maintainer adds your repo to the Skill Hub so it appears on [skills.cloud.sap](https://skills.cloud.sap).
+
+#### 1. Structure your repository
+
+Your repository must follow this layout for the Skill Hub to discover your skills:
+
+```
+your-repo/
+├── package.json          # must include an "author" field
+└── skills/
+    └── <skill-slug>/
+        └── SKILL.md      # must include "name" and "description" frontmatter
+```
+
+Example `SKILL.md`:
+
+```markdown
+---
+name: My Skill
+description: Does X when the user asks about Y. Use this skill whenever...
+---
+
+# My Skill
+
+...skill content...
+```
+
+The `description` field is what appears on the Skill Hub listing and drives AI trigger matching — make it specific and trigger-rich.
+
+#### 2. Open a registration issue
+
+Once your repository is ready and public on github.com, open a [Register a New Skill](https://github.com/SAP/ai-skills-library/issues/new?template=new-skill.yml) issue. A maintainer will review your submission and onboard your repo to the Skill Hub.
 
 ## Governing Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,11 @@ To avoid duplicate efforts and make sure your contribution is a good fit, please
 
 ### Registering a New Skill
 
-The AI Skills Library uses a **bring-your-own-repo** model. Your skill code lives in your own public GitHub repository — you do not submit skill code to this repository. Instead, you open an issue to request onboarding, and a maintainer adds your repo to the Skill Hub so it appears on [skills.cloud.sap](https://skills.cloud.sap).
+The AI Skills Library uses a **bring-your-own-repo** model. Your skill code lives in your own public GitHub repository — you do not submit skill code to this repository. Instead, you open an issue to request onboarding, and a maintainer adds your repo to the AI Skills Library so it appears on [skills.cloud.sap](https://skills.cloud.sap).
 
 #### 1. Structure your repository
 
-Your repository must follow this layout for the Skill Hub to discover your skills:
+Your repository must follow this layout for the AI Skills Library to discover your skills:
 
 ```
 your-repo/
@@ -47,11 +47,11 @@ description: Does X when the user asks about Y. Use this skill whenever...
 ...skill content...
 ```
 
-The `description` field is what appears on the Skill Hub listing and drives AI trigger matching — make it specific and trigger-rich.
+The `description` field is what appears on the AI Skills Library listing and drives AI trigger matching — make it specific and trigger-rich.
 
 #### 2. Open a registration issue
 
-Once your repository is ready and public on github.com, open a [Register a New Skill](https://github.com/SAP/ai-skills-library/issues/new?template=new-skill.yml) issue. A maintainer will review your submission and onboard your repo to the Skill Hub.
+Once your repository is ready and public on github.com, open a [Register a New Skill](https://github.com/SAP/ai-skills-library/issues/new?template=new-skill.yml) issue. A maintainer will review your submission and onboard your repo to the AI Skills Library.
 
 ## Governing Rules
 


### PR DESCRIPTION
## Summary

- Replaced the "New Skill" issue template with a "Register a New Skill" template that captures: repo URL, a brief skills listing (slug + one-liner per skill), and a readiness checklist (public repo, correct `skills/<slug>/SKILL.md` structure, root `package.json` with `author`)
- Removed fields that are no longer relevant (skill name, description, trigger conditions, content sources) — these are derived automatically by the Skill Hub parser from the contributor's repo
- Updated `CONTRIBUTING.md` to explain the bring-your-own-repo model and split the contributing paths into two clear sections: registering a new skill (issue-based) and improving an existing skill (fork + PR)
- Added a repository structure reference and `SKILL.md` example to `CONTRIBUTING.md` so contributors know exactly what to prepare before submitting

## Test plan

- [ ] Open the "Register a New Skill" issue template on GitHub and verify all fields render correctly (URL input, skills textarea, three required checkboxes, optional additional context)
- [ ] Verify the readiness checkboxes are all marked `required: true` and block submission when unchecked
- [ ] Check that `CONTRIBUTING.md` renders correctly on GitHub — code blocks, links to issue templates, and directory tree all display as expected
- [ ] Confirm the "Improve Existing Skill" template and docs-fix path are unchanged