### PR TITLE
feat: add dataflow diagram skill

### DIFF
--- a/skills/dataflow/SKILL.md
+++ b/skills/dataflow/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: Dataflow Diagram
+description: Generates an interactive data flow diagram as a self-contained HTML file from a free-text description. Use this skill whenever the user asks to visualize a data pipeline, data flow, system integration, or ETL process. Trigger on: "draw a data flow", "visualize my pipeline", "create a flow diagram", "map data sources", "show me how data moves".
+---
+
+# Dataflow Diagram
+
+Generates an interactive data flow diagram as a self-contained HTML file using a canvas-based particle engine with draggable nodes, pan/zoom, and animated particles flowing along edges.
+
+**Usage:** `/dataflow <description of the flow in free text>`
+
+## Steps
+
+1. **Infer nodes and edges** from the free-text description.
+
+   Node types:
+   - `n-source` — orange — data origin / SAP source system
+   - `n-process` — blue — transformation / computation
+   - `n-storage` — purple — database / data store
+   - `n-queue` — cyan — message queue / event stream
+   - `n-decision` — amber — condition / approval gate
+   - `n-output` — green — final destination / data product
+   - `n-external` — red — third-party / external API
+   - `n-actor` — slate — human role / team
+
+2. **Show summary** — list nodes and edges, then ask: *"Looks right? Say 'go' to generate, or tell me what to adjust."*
+
+3. **Generate the HTML file** to the user's working directory. The file is fully self-contained with embedded JS/CSS.
+
+4. **Confirm** with file path, node/edge counts, and instructions to open in browser.


### PR DESCRIPTION
## New Skill: Dataflow Diagram

Adds the `dataflow` skill for generating interactive data flow diagrams as self-contained HTML files.

### What it does
- Takes a free-text description of a data flow / pipeline
- Infers nodes and edges with typed visual styles (source, process, storage, queue, decision, output, external, actor)
- Generates a self-contained HTML file with a canvas-based particle engine: draggable nodes, pan/zoom, animated particles along edges

### Trigger examples
- "draw a data flow for my pipeline"
- "visualize my data sources"
- "create a flow diagram for this integration"
- "show me how data moves from SAP to Datasphere"

### License
Apache 2.0